### PR TITLE
Fix Node version error and show build output

### DIFF
--- a/build-unlimited-debian11.sh
+++ b/build-unlimited-debian11.sh
@@ -8,7 +8,9 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 LOG_FILE="$(dirname "$0")/build-debian11.log"
-exec > >(tee "${LOG_FILE}") 2>&1
+# Log both to file and to stdout with line buffering so output
+# is immediately visible in the terminal
+exec > >(stdbuf -oL tee "${LOG_FILE}") 2>&1
 
 finish() {
   REPO_DIR="$(dirname "$0")"

--- a/onlyoffice-package-builder.sh
+++ b/onlyoffice-package-builder.sh
@@ -131,7 +131,7 @@ fi
 
 PRUNE_DOCKER_CONTAINERS_ACTION="false"
 if [ "x${PRUNE_DOCKER_CONTAINERS}" != "x" ] ; then
-  if [ ${PRUNE_DOCKER_CONTAINERS} == "true" ] -o [ ${PRUNE_DOCKER_CONTAINERS} == "TRUE" ] ; then
+  if [ "${PRUNE_DOCKER_CONTAINERS}" = "true" ] || [ "${PRUNE_DOCKER_CONTAINERS}" = "TRUE" ] ; then
     PRUNE_DOCKER_CONTAINERS_ACTION="true"
     cat << EOF
     WARNING !
@@ -166,7 +166,8 @@ build_oo_binaries() {
   cd build_tools
   mkdir ${_OUT_FOLDER}
   docker build --tag onlyoffice-document-editors-builder .
-  docker run -e PRODUCT_VERSION=${_PRODUCT_VERSION} -e BUILD_NUMBER=${_BUILD_NUMBER} -e NODE_ENV='production' -v $(pwd)/${_OUT_FOLDER}:/build_tools/out onlyoffice-document-editors-builder /bin/bash -c 'cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
+  docker run -e PRODUCT_VERSION=${_PRODUCT_VERSION} -e BUILD_NUMBER=${_BUILD_NUMBER} -e NODE_ENV='production' -v $(pwd)/${_OUT_FOLDER}:/build_tools/out \
+    onlyoffice-document-editors-builder /bin/bash -c 'curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get -qq install -y nodejs && cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
   cd ..
 
 }


### PR DESCRIPTION
## Summary
- ensure console output is visible with `stdbuf -oL tee`
- install Node.js 18 inside document editors builder container
- clean up prune containers check

## Testing
- `shellcheck build-unlimited-debian11.sh onlyoffice-package-builder.sh deb_build/onlyoffice-deb-builder.sh`

------
https://chatgpt.com/codex/tasks/task_e_68877e52c588832b87654423dded3e7b