### PR TITLE
Fix build script exit behavior

### DIFF
--- a/onlyoffice-package-builder.sh
+++ b/onlyoffice-package-builder.sh
@@ -173,8 +173,16 @@ build_oo_binaries() {
   fi
   mkdir ${_OUT_FOLDER}
   docker build --tag onlyoffice-document-editors-builder .
-  docker run -e PRODUCT_VERSION=${_PRODUCT_VERSION} -e BUILD_NUMBER=${_BUILD_NUMBER} -e NODE_ENV='production' -v $(pwd)/${_OUT_FOLDER}:/build_tools/out onlyoffice-document-editors-builder /bin/bash -c 'cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
+  docker run \
+    -e PRODUCT_VERSION=${_PRODUCT_VERSION} \
+    -e BUILD_NUMBER=${_BUILD_NUMBER} \
+    -e NODE_ENV='production' \
+    -v $(pwd)/${_OUT_FOLDER}:/build_tools/out \
+    onlyoffice-document-editors-builder \
+    /bin/bash -c 'cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
+  run_exit=$?
   cd ..
+  return ${run_exit}
 
 }
 


### PR DESCRIPTION
## Summary
- fail `onlyoffice-package-builder.sh` if binary build container exits with error

## Testing
- `shellcheck onlyoffice-package-builder.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888939279b0832b94a1437d5b98c0e5