### PR TITLE
Fix build scripts to use updated repo and python3

### DIFF
--- a/build-unlimited-debian11.sh
+++ b/build-unlimited-debian11.sh
@@ -7,13 +7,13 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-LOG_FILE="$(dirname "$0")/build-debian11.log"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_FILE="${SCRIPT_DIR}/build-debian11.log"
 exec > >(tee "${LOG_FILE}") 2>&1
 
 finish() {
-  REPO_DIR="$(dirname "$0")"
-  cp "${LOG_FILE}" "${REPO_DIR}/debian11debug"
-  cd "${REPO_DIR}"
+  cp "${LOG_FILE}" "${SCRIPT_DIR}/debian11debug"
+  cd "${SCRIPT_DIR}"
   git add debian11debug
   git commit -m "Update debian11debug"
 }
@@ -120,7 +120,6 @@ mkdir -p ~/build-oo
 cd ~/build-oo
 git clone git@github.com:${GH_USER}/unlimited-onlyoffice-package-builder.git
 cd unlimited-onlyoffice-package-builder
-git checkout v0.0.1
 ./onlyoffice-package-builder.sh --product-version=${PRODUCT_VERSION} --build-number=${BUILD_NUMBER} --unlimited-organization=${GH_USER} --tag-suffix=-${BRAND} --debian-package-suffix=-${BRAND}
 
 echo "\nFertig. Das DEB Paket befindet sich unter: ~/build-oo/unlimited-onlyoffice-package-builder/document-server-package/deb/"

--- a/onlyoffice-package-builder.sh
+++ b/onlyoffice-package-builder.sh
@@ -131,7 +131,7 @@ fi
 
 PRUNE_DOCKER_CONTAINERS_ACTION="false"
 if [ "x${PRUNE_DOCKER_CONTAINERS}" != "x" ] ; then
-  if [ ${PRUNE_DOCKER_CONTAINERS} == "true" ] -o [ ${PRUNE_DOCKER_CONTAINERS} == "TRUE" ] ; then
+  if [ "${PRUNE_DOCKER_CONTAINERS}" = "true" ] || [ "${PRUNE_DOCKER_CONTAINERS}" = "TRUE" ] ; then
     PRUNE_DOCKER_CONTAINERS_ACTION="true"
     cat << EOF
     WARNING !
@@ -171,10 +171,28 @@ build_oo_binaries() {
   if ! grep -q "git" Dockerfile; then
     sed -i '/python3 \\/a\                       git \\' Dockerfile
   fi
+  if grep -q 'ln -s /usr/bin/python2 /usr/bin/python' Dockerfile; then
+    sed -i 's|ln -s /usr/bin/python2 /usr/bin/python|ln -s /usr/bin/python3 /usr/bin/python|' Dockerfile
+  fi
   mkdir ${_OUT_FOLDER}
   docker build --tag onlyoffice-document-editors-builder .
-  docker run -e PRODUCT_VERSION=${_PRODUCT_VERSION} -e BUILD_NUMBER=${_BUILD_NUMBER} -e NODE_ENV='production' -v $(pwd)/${_OUT_FOLDER}:/build_tools/out onlyoffice-document-editors-builder /bin/bash -c 'cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
+  docker run \
+    -e PRODUCT_VERSION=${_PRODUCT_VERSION} \
+    -e BUILD_NUMBER=${_BUILD_NUMBER} \
+    -e NODE_ENV='production' \
+    -v $(pwd)/${_OUT_FOLDER}:/build_tools/out \
+    onlyoffice-document-editors-builder \
+    /bin/bash -c 'cd tools/linux && python3 ./automate.py --branch=tags/'"${_GIT_CLONE_BRANCH}"
+  run_exit=$?
+  if [ ${run_exit} -eq 0 ]; then
+    ds_dir="${_OUT_FOLDER}/linux_64/onlyoffice/documentserver"
+    if [ ! -d "${ds_dir}" ] || [ -z "$(ls -A "${ds_dir}" 2>/dev/null)" ]; then
+      echo "DocumentServer binaries not found in ${ds_dir}" >&2
+      run_exit=1
+    fi
+  fi
   cd ..
+  return ${run_exit}
 
 }
 


### PR DESCRIPTION
## Summary
- avoid checking out old tag when running Debian 11 helper script
- ensure build_tools Dockerfile uses python3 rather than python2

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck build-unlimited-debian11.sh onlyoffice-package-builder.sh`


------
https://chatgpt.com/codex/tasks/task_e_6888939279b0832b94a1437d5b98c0e5